### PR TITLE
Fix for MongoDB Compatibility Issue

### DIFF
--- a/secondChance-backend/package.json
+++ b/secondChance-backend/package.json
@@ -18,7 +18,7 @@
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
-    "mongodb": "^6.3.0",
+    "mongodb": "6.8.0",
     "multer": "^1.4.5-lts.1",
     "pino": "^8.17.2",
     "pino-http": "^9.0.0",

--- a/secondChance-backend/util/import-mongo/package-lock.json
+++ b/secondChance-backend/util/import-mongo/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.3.1",
-        "mongodb": "6.8.0"
+        "mongodb": "^6.3.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {

--- a/secondChance-backend/util/import-mongo/package-lock.json
+++ b/secondChance-backend/util/import-mongo/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.3.1",
-        "mongodb": "^6.3.0"
+        "mongodb": "6.8.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {

--- a/secondChance-backend/util/import-mongo/package.json
+++ b/secondChance-backend/util/import-mongo/package.json
@@ -12,6 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.3.1",
-    "mongodb": "^6.3.0"
+    "mongodb": "6.8.0"
   }
 }


### PR DESCRIPTION
When running the Node.js server, the following error occurs:
MongoServerSelectionError: _Server at 172.21.201.54:27017 reports maximum wire version 6, but this version of the Node.js Driver requires at least 7 (MongoDB 4.0)_.

This error is caused by an incompatibility between the lab's MongoDB server version (3.6) and the MongoDB Node.js driver, which requires MongoDB 4.0 or higher.

To resolve this issue, the MongoDB driver has to be downgraded to version 6.8 in package.json, ensuring compatibility with MongoDB 3.6.